### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that connects AI agents and developers to structured, context-ready blockchain data across multiple networks through Nodit's Web3 infrastructure.
 
+<a href="https://glama.ai/mcp/servers/@noditlabs/nodit-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@noditlabs/nodit-mcp-server/badge" alt="Nodit Server MCP server" />
+</a>
+
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D18.0.0-green.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0%2B-blue.svg)](https://www.typescriptlang.org/)


### PR DESCRIPTION
This PR adds a badge for the [Nodit MCP Server](https://glama.ai/mcp/servers/@noditlabs/nodit-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@noditlabs/nodit-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@noditlabs/nodit-mcp-server/badge" alt="Nodit Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.