### PR TITLE
Create glama.json

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "nodit-developers"
+  ]
+}


### PR DESCRIPTION
This change enables MCP ownership claim on the Glama site by adding the owner’s GitHub username to the listing entry.
